### PR TITLE
feat(nix): added nix flake into respoitory

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,26 @@ jobs:
   build:
     strategy:
       matrix:
-        theme: [ acheron argenti blackswan dr.ratio hanya huohuo luocha ruanmei sparkle acheron_cn argenti_cn blackswan_cn dr.ratio_cn hanya_cn huohuo_cn luocha_cn ruanmei_cn sparkle_cn ]
+        theme: [
+            acheron
+            argenti
+            blackswan
+            dr.ratio
+            hanya
+            huohuo
+            luocha
+            ruanmei
+            sparkle
+            acheron_cn
+            argenti_cn
+            blackswan_cn
+            dr.ratio_cn
+            hanya_cn
+            huohuo_cn
+            luocha_cn
+            ruanmei_cn
+            sparkle_cn,
+          ]
     name: Build Nix
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,35 @@
+name: Check nix packages
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  push:
+    branches: [master]
+jobs:
+  check:
+    name: Check Nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Nix flake inputs
+        uses: DeterminateSystems/flake-checker-action@v5
+        with:
+          send-statistics: false
+          fail-mode: true
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+      - name: Check repository
+        run: nix flake check
+      - name: Build packages
+        run: nix build .#${{ matrix.theme }}-grub-theme
+  build:
+    strategy:
+      matrix:
+        theme: [ acheron argenti blackswan dr.ratio hanya huohuo luocha ruanmei sparkle acheron_cn argenti_cn blackswan_cn dr.ratio_cn hanya_cn huohuo_cn luocha_cn ruanmei_cn sparkle_cn ]
+    name: Build Nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+      - name: Build packages
+        run: nix build .#${{ matrix.theme }}-grub-theme

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,30 +19,28 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v9
       - name: Check repository
         run: nix flake check
-      - name: Build packages
-        run: nix build .#${{ matrix.theme }}-grub-theme
   build:
     strategy:
       matrix:
         theme: [
-            acheron
-            argenti
-            blackswan
-            dr.ratio
-            hanya
-            huohuo
-            luocha
-            ruanmei
-            sparkle
-            acheron_cn
-            argenti_cn
-            blackswan_cn
-            dr.ratio_cn
-            hanya_cn
-            huohuo_cn
-            luocha_cn
-            ruanmei_cn
-            sparkle_cn,
+            acheron,
+            argenti,
+            blackswan,
+            dr.ratio,
+            hanya,
+            huohuo,
+            luocha,
+            ruanmei,
+            sparkle,
+            acheron_cn,
+            argenti_cn,
+            blackswan_cn,
+            dr.ratio_cn,
+            hanya_cn,
+            huohuo_cn,
+            luocha_cn,
+            ruanmei_cn,
+            sparkle_cn
           ]
     name: Build Nix
     runs-on: ubuntu-latest

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,11 +22,15 @@ jobs:
   build:
     strategy:
       matrix:
+        # Remember. Theme name in pipeline has 2 rules:
+        # - lower case names e.g. RuaMei -> ruamei
+        # - each '.' must be replaced by "_" e.g Dr.Ratio -> dr_ratio
+        # Those requiements are only for nix packages
         theme: [
             acheron,
             argenti,
             blackswan,
-            dr.ratio,
+            dr_ratio,
             hanya,
             huohuo,
             luocha,
@@ -35,7 +39,7 @@ jobs:
             acheron_cn,
             argenti_cn,
             blackswan_cn,
-            dr.ratio_cn,
+            dr_ratio_cn,
             hanya_cn,
             huohuo_cn,
             luocha_cn,

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.envrc
+.direnv
+.vscode
+result

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ sudo grub-mkconfig -o /boot/grub/grub.cfg
 ```
 
 6. Reboot the computer
+
+### For NixOS users
+1. Added flake into your configuration
+```nix
+inputs.honkai-railway-grub-theme.url = "github:voidlhf/StarRailGrubThemes";
+```
+
+2. Set up theme in your configuration
+```nix
+honkai-railway-grub-theme = {
+    enable = true;
+    # Remember
+    # Theme name should have the same name as in assets/themes directory e.g. Dr.Ratio_cn is correct
+    # 'theme' field is optional. Default theme is Acheron.
+    theme = "RuanMei"; 
+};
+```
+
+3. Rebuild your system
+4. Reboot computer to see your theme :)
+
 ## Preview
 ![Acheron](/preview/Acheron.png)
 ![BlackSwan](/preview/BlackSwan.png)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ sudo grub-mkconfig -o /boot/grub/grub.cfg
 6. Reboot the computer
 
 ### For NixOS users
+For NixOS users, it was prepered packages and NixOS module to install theme
+#### With NixOS Module
 1. Added flake into your configuration
 ```nix
 inputs.honkai-railway-grub-theme.url = "github:voidlhf/StarRailGrubThemes";
@@ -60,6 +62,23 @@ honkai-railway-grub-theme = {
     # Theme name should have the same name as in assets/themes directory e.g. Dr.Ratio_cn is correct
     # 'theme' field is optional. Default theme is Acheron.
     theme = "RuanMei"; 
+};
+```
+#### Without NixOS module
+1. Added flake into your configuration
+```nix
+inputs.honkai-railway-grub-theme.url = "github:voidlhf/StarRailGrubThemes";
+```
+
+3. Added GRUB theme
+```nix
+boot.loader.grub = rec {
+    # Remember. Each nix package from this repo have another name.
+    # Packages name have 2 rules:
+    # - lower case names e.g. RuaMei -> ruamei
+    # - each '.' must be replaced by "_" e.g Dr.Ratio -> dr_ratio
+    theme = inputs.inputs.honkai-railway-grub-theme.packages.${system}.<your_theme_name>-grub-theme;
+    splashImage = "${theme}/background.png";
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,14 @@ sudo grub-mkconfig -o /boot/grub/grub.cfg
 inputs.honkai-railway-grub-theme.url = "github:voidlhf/StarRailGrubThemes";
 ```
 
-2. Set up theme in your configuration
+2. Added honkai-railway-grub-theme as NixOS Module
+```nix
+# your configuration.nix
+# ${system} - system architectuer e.g. x86_64-linux
+imports = [ home-inputs.honkai-railway-grub-theme.nixosModules.${system}.default ];
+```
+
+3. Set up theme in your configuration
 ```nix
 honkai-railway-grub-theme = {
     enable = true;
@@ -56,8 +63,8 @@ honkai-railway-grub-theme = {
 };
 ```
 
-3. Rebuild your system
-4. Reboot computer to see your theme :)
+4. Rebuild your system
+5. Reboot computer to see your theme :)
 
 ## Preview
 ![Acheron](/preview/Acheron.png)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ honkai-railway-grub-theme = {
 inputs.honkai-railway-grub-theme.url = "github:voidlhf/StarRailGrubThemes";
 ```
 
-3. Added GRUB theme
+2. Added GRUB theme
 ```nix
 boot.loader.grub = rec {
     # Remember. Each nix package from this repo have another name.
@@ -82,8 +82,8 @@ boot.loader.grub = rec {
 };
 ```
 
-4. Rebuild your system
-5. Reboot computer to see your theme :)
+3. Rebuild your system
+4. Reboot computer to see your theme :)
 
 ## Preview
 ![Acheron](/preview/Acheron.png)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,27 @@
+{ stdenvNoCC
+, lib
+, fetchFromGitHub
+, theme
+}:
+
+let
+  themes = builtins.attrNames (builtins.readDir ./assets/themes);
+in
+
+assert builtins.any (x: x == theme) themes;
+
+stdenvNoCC.mkDerivation {
+  name = "StarRailGrubThemes";
+
+  src = ./.;
+
+  installPhase = "cp -r ./assets/themes/${theme} $out";
+
+  meta = with lib; {
+    homepage = "https://github.com/voidlhf/StarRailGrubThemes";
+    description = "A pack of GRUB2 themes for Honkai: Star Rail";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ Wittano ];
+    platforms = platforms.linux;
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,14 @@
 
         themeNames = builtins.attrNames (builtins.readDir ./assets/themes);
         themePackages = builtins.listToAttrs (builtins.map
-          (theme: {
-            name = "${pkgs.lib.strings.toLower theme}-grub-theme";
-            value = pkgs.callPackage ./default.nix { inherit theme; };
-          })
+          (theme:
+            let
+              name = builtins.replaceStrings [ "." ] [ "_" ] (pkgs.lib.strings.toLower theme);
+            in
+            {
+              inherit name;
+              value = pkgs.callPackage ./default.nix { inherit theme; };
+            })
           themeNames);
       in
       {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "A pack of GRUB2 themes for Honkai: Star Rail";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      systems = [ "aarch64-linux" "i686-linux" "x86_64-linux" ];
+    in
+    flake-utils.lib.eachSystem systems (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        themeNames = builtins.attrNames (builtins.readDir ./assets/themes);
+        themePackages = builtins.listToAttrs (builtins.map
+          (theme: {
+            name = "${pkgs.lib.strings.toLower theme}-grub-theme";
+            value = pkgs.callPackage ./default.nix { inherit theme; };
+          })
+          themeNames);
+      in
+      {
+        packages = {
+          default = pkgs.callPackage ./default.nix { theme = "Acheron"; };
+        } // themePackages;
+
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [ nixpkgs-fmt nixd ];
+        };
+
+        nixosModules.default = ./module.nix;
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         themePackages = builtins.listToAttrs (builtins.map
           (theme:
             let
-              name = builtins.replaceStrings [ "." ] [ "_" ] (pkgs.lib.strings.toLower theme);
+              name = (builtins.replaceStrings [ "." ] [ "_" ] (pkgs.lib.strings.toLower theme)) + "-grub-theme";
             in
             {
               inherit name;

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,26 @@
+{ config, pkgs, lib, ... }:
+with lib;
+let
+  cfg = config.honkai-railway-grub-theme;
+  themeNames = builtins.attrNames (builtins.readDir ./assets/themes);
+in
+{
+  options = {
+    honkai-railway-grub-theme = {
+      enable = mkEnableOption "Enable Honaki Railway GRUB2 theme";
+      theme = mkOption {
+        type = types.enum themeNames;
+        default = "Acheron";
+        example = "Dr.Ratio";
+        description = "Selected theme name. IMPORTANT! Theme name must be the same as in assert/themes directory";
+      };
+    };
+  };
+
+  config = mkIf (cfg.enable) {
+    boot.loader.grub = {
+      theme = pkgs.callPackage ./default.nix { theme = cfg.theme; };
+      splashImage = ./assets/themes/${cfg.theme}/background.png;
+    };
+  };
+}


### PR DESCRIPTION
Hi @voidlhf, I added installation support for NixOS users. To install your packages, we need additional repository(flake), which allow us install your theme into ours systems. From your perspective, you don't have to do anything(only added  theme name into pipeline) with this, because I created scripts, that imports builds and distributes new themes after you added into repo.